### PR TITLE
Guard slider script against missing elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -1406,6 +1406,7 @@
     let total = slides ? slides.children.length : 0;
 
     function go(n) {
+      if (!slides || !slider) return;
       idx = (n + total) % total;
       const w = slider.getBoundingClientRect().width; // largura real do trilho
       slides.style.transform = `translateX(-${idx * w}px)`;


### PR DESCRIPTION
## Summary
- prevent the slider script from throwing errors when the elements are absent by checking for their existence before calculating dimensions

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab6a8f7cc48326af7fc221fa311549